### PR TITLE
development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # terminal-utils
 A simple library for creating CLIs using [crossterm-rs](https://github.com/crossterm-rs/crossterm).
+test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # terminal-utils
 A simple library for creating CLIs using [crossterm-rs](https://github.com/crossterm-rs/crossterm).
-test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# terminal-utils
+A simple library for creating CLIs using [crossterm-rs](https://github.com/crossterm-rs/crossterm).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,20 +6,35 @@ use crossterm::{
     execute,
     style::*,
     terminal::{disable_raw_mode, enable_raw_mode, size},
+    ErrorKind,
 };
 use std::io::stdout;
 
-const DEBUG: bool = false;
+pub enum TerminalErrKind {
+    ArrayTooLongErr,
+    ConsoleWriteErr(ErrorKind),
+}
 
-/// clears the given amount of lines and move to the line started with
+pub struct TerminalError {
+    pub err_type: TerminalErrKind,
+    pub err_msg: String,
+}
+
+impl TerminalError {
+    pub fn new(err_type: TerminalErrKind, err_msg: String) -> Self {
+        Self { err_type, err_msg }
+    }
+}
+
+/// clears the given amount of lines and moves the given amount of lines up
 #[allow(unused)]
-pub fn clear(length: &u16) -> bool {
+pub fn clear(length: &u16) -> Option<TerminalError> {
     let result_size = size();
     if result_size.is_err() {
-        if DEBUG {
-            println!("{}", result_size.unwrap_err());
-        }
-        return false;
+        return Some(TerminalError::new(
+            TerminalErrKind::ConsoleWriteErr(result_size.unwrap_err()),
+            "An console write error fired!".to_string(),
+        ));
     }
     let size = result_size.unwrap();
     for _ in 0..*length {
@@ -28,158 +43,235 @@ pub fn clear(length: &u16) -> bool {
             Print(format!("{}{}", " ".repeat(size.0 as usize), "\n\r"))
         );
         if result_cl0.is_err() {
-            if DEBUG {
-                println!("{}", result_cl0.unwrap_err());
-            }
-            return false;
+            return Some(TerminalError::new(
+                TerminalErrKind::ConsoleWriteErr(result_cl0.unwrap_err()),
+                "An console write error fired!".to_string(),
+            ));
         }
     }
     let result_cl1 = execute!(stdout(), MoveToPreviousLine(*length));
     if result_cl1.is_err() {
-        if DEBUG {
-            println!("{}", result_cl1.unwrap_err());
-        }
-        return false;
+        return Some(TerminalError::new(
+            TerminalErrKind::ConsoleWriteErr(result_cl1.unwrap_err()),
+            "An console write error fired!".to_string(),
+        ));
     }
-    true
+    None
 }
 
 /// choose a string out of an array
 /// maximum length: 16
 /// minimum length: 2
 #[allow(unused)]
-pub fn choose(options: &[String]) -> Option<u8> {
+pub fn choose(
+    options: &[String],
+    selected_prefix: &String,
+    selected_suffix: &String,
+    selected_color: Color,
+    prefix: &String,
+    suffix: &String,
+    color: Color,
+    infinite_cycle: bool,
+) -> Result<u8, TerminalError> {
     if options.len() > 16 || options.len() < 2 {
-        if DEBUG {
-            println!(
-                "Length of options needs to be  1 < len < 17 but is {}",
+        return Err(TerminalError::new(
+            TerminalErrKind::ArrayTooLongErr,
+            format!(
+                "Length of options needs to be  1 < len < 17 but is {}!",
                 options.len()
-            );
-        }
-        return None;
+            )
+            .to_string(),
+        ));
     }
     let result_ch0 = execute!(stdout(), Hide);
     if result_ch0.is_err() {
-        if DEBUG {
-            println!("{}", result_ch0.unwrap_err());
-        }
-        return None;
+        return Err(TerminalError::new(
+            TerminalErrKind::ConsoleWriteErr(result_ch0.unwrap_err()),
+            "An console write error fired!".to_string(),
+        ));
     }
     let result_ch1 = enable_raw_mode();
     if result_ch1.is_err() {
-        if DEBUG {
-            println!("{}", result_ch1.unwrap_err());
-        }
-        return None;
+        return Err(TerminalError::new(
+            TerminalErrKind::ConsoleWriteErr(result_ch1.unwrap_err()),
+            "An console write error fired!".to_string(),
+        ));
     }
     let mut selected: u8 = 0;
-    fn prt(options: &[String], selected: &mut u8) -> bool {
+    fn prt(
+        options: &[String],
+        selected: &mut u8,
+        selected_prefix: &String,
+        selected_suffix: &String,
+        selected_color: Color,
+        prefix: &String,
+        suffix: &String,
+        color: Color,
+    ) -> Option<ErrorKind> {
         let mut i = 0;
         for option in options {
             if *selected == i {
                 let result_pr0 = execute!(
                     stdout(),
-                    PrintStyledContent(format!("> {}\n\r", option).blue())
+                    PrintStyledContent(
+                        format!("{}{}{}\n\r", selected_prefix, option, selected_suffix)
+                            .on(selected_color.clone())
+                    )
                 );
                 if result_pr0.is_err() {
-                    if DEBUG {
-                        println!("{}", result_pr0.unwrap_err());
-                    }
-                    return false;
+                    return Some(result_pr0.unwrap_err());
                 }
             } else {
                 let result_pr1 = execute!(
                     stdout(),
-                    PrintStyledContent(format!("  {}\n\r", option).blue())
+                    PrintStyledContent(
+                        format!("{}{}{}\n\r", prefix, option, suffix).on(color.clone())
+                    )
                 );
                 if result_pr1.is_err() {
-                    if DEBUG {
-                        println!("{}", result_pr1.unwrap_err());
-                    }
-                    return false;
+                    return Some(result_pr1.unwrap_err());
                 }
             }
             i += 1;
         }
-        true
+        None
     }
-    prt(options, &mut selected);
+    let result_ch2 = prt(
+        options,
+        &mut selected,
+        selected_prefix,
+        selected_suffix,
+        selected_color.clone(),
+        prefix,
+        suffix,
+        color.clone(),
+    );
+    if result_ch2.is_some() {
+        return Err(TerminalError::new(
+            TerminalErrKind::ConsoleWriteErr(result_ch2.unwrap()),
+            "An console write error fired!".to_string(),
+        ));
+    }
     loop {
-        let result_ch2 = read();
-        if result_ch2.is_err() {
-            if DEBUG {
-                println!("{}", result_ch2.unwrap_err());
-            }
-            return None;
+        let result_ch3 = read();
+        if result_ch3.is_err() {
+            return Err(TerminalError::new(
+                TerminalErrKind::ConsoleWriteErr(result_ch3.unwrap_err()),
+                "An console write error fired!".to_string(),
+            ));
         }
-        let key = result_ch2.unwrap();
+        let key = result_ch3.unwrap();
         match key {
             Event::Key(it) => {
                 if it.code == KeyCode::Up {
-                    if selected > 0 {
+                    if infinite_cycle {
                         selected -= 1;
-                        if execute!(
-                            stdout(),
-                            MoveToPreviousLine((options.len()) as u16),
-                            MoveToColumn(1)
-                        )
-                        .is_err()
-                            || !clear(&(options.len() as u16))
-                            || !prt(options, &mut selected)
-                        {
-                            if DEBUG {
-                                println!("err/choose/match-key-1");
-                            }
-                            return None;
+                        if selected < 0 {
+                            selected = (options.len() - 1) as u8;
                         }
+                    } else {
+                        if selected > 0 {
+                            selected -= 1;
+                        }
+                    }
+                    let result_ch4 = execute!(
+                        stdout(),
+                        MoveToPreviousLine((options.len()) as u16),
+                        MoveToColumn(1)
+                    );
+                    if result_ch4.is_err() {
+                        return Err(TerminalError::new(
+                            TerminalErrKind::ConsoleWriteErr(result_ch4.unwrap_err()),
+                            "An console write error fired!".to_string(),
+                        ));
+                    }
+                    let result_ch5 = clear(&(options.len() as u16));
+                    if result_ch5.is_some() {
+                        return Err(result_ch5.unwrap());
+                    }
+                    let result_ch6 = prt(
+                        options,
+                        &mut selected,
+                        selected_prefix,
+                        selected_suffix,
+                        selected_color.clone(),
+                        prefix,
+                        suffix,
+                        color.clone(),
+                    );
+                    if result_ch6.is_some() {
+                        return Err(TerminalError::new(
+                            TerminalErrKind::ConsoleWriteErr(result_ch6.unwrap()),
+                            "An console write error fired!".to_string(),
+                        ));
                     }
                 } else if it.code == KeyCode::Down {
-                    if selected < (options.len() - 1) as u8 {
+                    if infinite_cycle {
                         selected += 1;
-                        if execute!(
-                            stdout(),
-                            MoveToPreviousLine((options.len()) as u16),
-                            MoveToColumn(1)
-                        )
-                        .is_err()
-                            || !clear(&(options.len() as u16))
-                            || !prt(options, &mut selected)
-                        {
-                            if DEBUG {
-                                println!("err/choose/match-key-2");
-                            }
-                            return None;
+                        if selected >= options.len() as u8 {
+                            selected = 0;
                         }
+                    } else {
+                        if selected < (options.len() - 1) as u8 {
+                            selected += 1;
+                        }
+                    }
+                    let result_ch4 = execute!(
+                        stdout(),
+                        MoveToPreviousLine((options.len()) as u16),
+                        MoveToColumn(1)
+                    );
+                    if result_ch4.is_err() {
+                        return Err(TerminalError::new(
+                            TerminalErrKind::ConsoleWriteErr(result_ch4.unwrap_err()),
+                            "An console write error fired!".to_string(),
+                        ));
+                    }
+                    let result_ch5 = clear(&(options.len() as u16));
+                    if result_ch5.is_some() {
+                        return Err(result_ch5.unwrap());
+                    }
+                    let result_ch6 = prt(
+                        options,
+                        &mut selected,
+                        selected_prefix,
+                        selected_suffix,
+                        selected_color.clone(),
+                        prefix,
+                        suffix,
+                        color.clone(),
+                    );
+                    if result_ch6.is_some() {
+                        return Err(TerminalError::new(
+                            TerminalErrKind::ConsoleWriteErr(result_ch6.unwrap()),
+                            "An console write error fired!".to_string(),
+                        ));
                     }
                 } else if it.code == KeyCode::Enter {
-                    if execute!(
+                    let result_ch4 = execute!(
                         stdout(),
-                        MoveToPreviousLine(options.len() as u16),
-                        MoveToColumn(1)
-                    )
-                    .is_err()
-                        || !clear(&(options.len() as u16))
-                    {
-                        if DEBUG {
-                            println!("err/choose/match-key-3");
-                        }
-                        return None;
-                    }
-                    let result_ch3 = execute!(stdout(), Show);
-                    if result_ch3.is_err() {
-                        if DEBUG {
-                            println!("{}", result_ch3.unwrap_err());
-                        }
-                        return None;
-                    }
-                    let result_ch4 = disable_raw_mode();
+                        MoveToPreviousLine((options.len()) as u16),
+                        MoveToColumn(1),
+                        Show
+                    );
                     if result_ch4.is_err() {
-                        if DEBUG {
-                            println!("{}", result_ch4.unwrap_err());
-                        }
-                        return None;
+                        return Err(TerminalError::new(
+                            TerminalErrKind::ConsoleWriteErr(result_ch4.unwrap_err()),
+                            "An console write error fired!".to_string(),
+                        ));
                     }
-                    return Some(selected);
+                    let result_ch5 = clear(&(options.len() as u16));
+                    if result_ch5.is_some() {
+                        return Err(result_ch5.unwrap());
+                    }
+                    let result_ch6 = disable_raw_mode();
+                    if result_ch6.is_err() {
+                        return Err(TerminalError::new(
+                            TerminalErrKind::ConsoleWriteErr(result_ch6.unwrap_err()),
+                            "An console write error fired!".to_string(),
+                        ));
+                    }
+                    return Ok(selected);
                 }
             }
             _ => {}


### PR DESCRIPTION
- Create README.md
- Update README.md
- Update README.md
- dded Result-Returntypes. Added TerminalError enum. Removed Debug-code. Added more options for the choose function:  - Prefix for selected option: 3rd parameter -> &String  - Suffix for selected option: 4th parameter -> &String  - Color for selected option: 5th parameter -> crossterm::style::Color  - Prefix for not selected option: 6th parameter -> &String  - Suffix for not selected option: 7th parameter -> &String  - Color for not selected option: 8th parameter -> crossterm::style::Color
- Added better colorization. Changed returntype of choose to Result<i8, TerminalError> from Result<u8, TerminalError> Changed parametertypes of choose: (Color = crossterm::style::Color) -selected_prefix -> &String -> StyledContent<&str> -selected_suffix -> &String -> StyledContent<&str> -selected_color -> Color -> (Option<Color>, Option<Color>) -prefix -> &String -> StyledContent<&str> -suffix -> &String -> StyledContent<&str> -color -> Color -> (Option<Color>, Option<Color>) Added parameter: infinite_cycle -> bool
